### PR TITLE
Fix baseurl global property

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ User guide
 --
 User guide on how to install and configure the module can be found here - [https://wiki.openmrs.org/display/docs/Open+Web+Apps+Module](https://wiki.openmrs.org/display/docs/Open+Web+Apps+Module)
 
-Developer tutorial
+Developer tutorials
 --
-The tutorial to create Open Web Apps can be found here - [https://wiki.openmrs.org/x/_o2QBQ](https://wiki.openmrs.org/x/_o2QBQ)
+Tutorials to create Open Web Apps can be found here:
+- [https://wiki.openmrs.org/x/_o2QBQ](https://wiki.openmrs.org/x/_o2QBQ)
+- https://wiki.openmrs.org/display/docs/Open+Web+App+Development+Workflow
+
+There is a Yeoman generator to automatically scaffold OpenMRS Open Web Apps [here](https://www.npmjs.com/package/generator-openmrs-owa).

--- a/omod/src/main/java/org/openmrs/module/owa/activator/OwaActivator.java
+++ b/omod/src/main/java/org/openmrs/module/owa/activator/OwaActivator.java
@@ -1,6 +1,6 @@
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0 + Health disclaimer. If a copy of the MPL was not 
+ * License, v. 2.0 + Health disclaimer. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://license.openmrs.org
  */
 package org.openmrs.module.owa.activator;
@@ -22,9 +22,9 @@ import org.openmrs.util.OpenmrsUtil;
  * This class contains the logic that is run every time this module is either started or stopped.
  */
 public class OwaActivator implements ModuleActivator {
-	
+
 	protected Log log = LogFactory.getLog(getClass());
-	
+
 	/**
 	 * @see ModuleActivator#willRefreshContext()
 	 */
@@ -32,7 +32,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willRefreshContext() {
 		log.info("Refreshing OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#contextRefreshed()
 	 */
@@ -44,7 +44,7 @@ public class OwaActivator implements ModuleActivator {
 		 */
 		String owaAppFolderPath = Context.getAdministrationService().getGlobalProperty(AppManager.KEY_APP_FOLDER_PATH);
 		if (null == owaAppFolderPath) {
-			owaAppFolderPath = OpenmrsUtil.getApplicationDataDirectory() + "owa";
+			owaAppFolderPath = OpenmrsUtil.getApplicationDataDirectory() + "/owa";
 			Context.getAdministrationService().setGlobalProperty(AppManager.KEY_APP_FOLDER_PATH, owaAppFolderPath);
 		}
 		String owaStarted = Context.getAdministrationService().getGlobalProperty("owa.started");
@@ -71,7 +71,7 @@ public class OwaActivator implements ModuleActivator {
 		}
 		log.info("OWA Module refreshed");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#willStart()
 	 */
@@ -79,7 +79,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willStart() {
 		log.info("Starting OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#started()
 	 */
@@ -87,7 +87,7 @@ public class OwaActivator implements ModuleActivator {
 	public void started() {
 		log.info("OWA started");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#willStop()
 	 */
@@ -95,7 +95,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willStop() {
 		log.info("Stopping OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#stopped()
 	 */
@@ -103,5 +103,5 @@ public class OwaActivator implements ModuleActivator {
 	public void stopped() {
 		log.info("OWA Module stopped");
 	}
-	
+
 }

--- a/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
+++ b/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
@@ -14,6 +14,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.owa.AppManager;
 
 /**
  * @author sunbiz
@@ -30,18 +31,21 @@ public class OwaFilter implements Filter {
 	@Override
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
 		HttpServletRequest request = (HttpServletRequest) req;
-		String requestURI = request.getRequestURI();
+		String requestURL = request.getRequestURL().toString();
+		
+		String owaBasePath = Context.getAdministrationService().getGlobalProperty(AppManager.KEY_APP_BASE_URL);
+		
 		if (Context.isAuthenticated()) {
-			if (requestURI.startsWith(openmrsPath + "/owa")) {
-				String newURI = requestURI.replace(openmrsPath + "/owa", "/ms/owa/fileServlet");
-				req.getRequestDispatcher(newURI).forward(req, res);
+			if (requestURL.startsWith(owaBasePath)) {
+				String newURL = requestURL.replace(owaBasePath, "/ms/owa/fileServlet");
+				req.getRequestDispatcher(newURL).forward(req, res);
 			} else {
 				chain.doFilter(req, res);
 			}
 		} else {
-			if (requestURI.startsWith(openmrsPath + "/owa")) {
-				String newURI = requestURI.replace(openmrsPath + "/owa", "/ms/owa/redirectServlet");
-				req.getRequestDispatcher(newURI).forward(req, res);
+			if (requestURL.startsWith(owaBasePath)) {
+				String newURL = requestURL.replace(owaBasePath, "/ms/owa/redirectServlet");
+				req.getRequestDispatcher(newURL).forward(req, res);
 			} else {
 				chain.doFilter(req, res);
 			}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -40,7 +40,7 @@
     </filter>
     <filter-mapping>
         <filter-name>owaFilter</filter-name>
-        <url-pattern>/owa/*</url-pattern>
+        <url-pattern>*</url-pattern>
     </filter-mapping>
 	
     <!-- Maps hibernate file's, if present -->

--- a/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
@@ -1,0 +1,100 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.owa.filter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.owa.AppManager;
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OwaFilterTest extends BaseModuleWebContextSensitiveTest {
+
+	private static String DEFAULT_APP_BASE_URL = "http://localhost:80/openmrs/owa";
+
+	private static String DEFAULT_APP_BASE_URI = "/openmrs/owa";
+
+	private static String SOME_RANDOM_BASE_URL = "http://localhost:80/openmrs/somethingbesidesthedefault";
+
+	private static String SOME_RANDOM_BASE_URI = "/openmrs/somethingbesidesthedefault";
+
+	private static String SOME_PATH_IN_APP = "/anything/index.hml";
+
+	private static String DUMMY_CONTEXT_PATH = "http://localhost:80/openmrs";
+
+	private static String FILE_SERVLET_REDIRECT_URL = "/ms/owa/fileServlet";
+
+	FilterConfig filterConfig;
+
+	ServletContext servletContext;
+
+	public OwaFilterTest() {
+
+	}
+
+	@Before
+	public void setUpMocks() {
+		filterConfig = mock(FilterConfig.class);
+		servletContext = mock(ServletContext.class);
+
+		when(servletContext.getContextPath()).thenReturn(DUMMY_CONTEXT_PATH);
+		when(filterConfig.getServletContext()).thenReturn(servletContext);
+	}
+
+	/**
+	 * Test that the OwaFilter class actually services from the base path defined in the global
+	 * property and ignore any other requests.
+	 */
+	@Test
+	public void testOwaFilterUsesGlobalProperty() throws Exception {
+		OwaFilter owaFilter = new OwaFilter();
+		owaFilter.init(filterConfig);
+
+		MockFilterChain mockFilterChain = new MockFilterChain();
+		MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+		// First make sure that it works with the default base URL
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(AppManager.KEY_APP_BASE_URL, DEFAULT_APP_BASE_URL));
+
+		MockHttpServletRequest req = new MockHttpServletRequest("GET", DEFAULT_APP_BASE_URI + SOME_PATH_IN_APP);
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertEquals(FILE_SERVLET_REDIRECT_URL + SOME_PATH_IN_APP, rsp.getForwardedUrl());
+
+		// Now try a custom base URL
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(AppManager.KEY_APP_BASE_URL, SOME_RANDOM_BASE_URL));
+		mockFilterChain = new MockFilterChain();
+		req = new MockHttpServletRequest("GET", SOME_RANDOM_BASE_URI + SOME_PATH_IN_APP);
+		rsp = new MockHttpServletResponse();
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertEquals(FILE_SERVLET_REDIRECT_URL + SOME_PATH_IN_APP, rsp.getForwardedUrl());
+
+		// Ensure non-OWA base URLs are ignored
+		req = new MockHttpServletRequest("GET",
+				DEFAULT_APP_BASE_URI + SOME_PATH_IN_APP); // we can reuse this URL because the global property has been reset
+		rsp = new MockHttpServletResponse();
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertNull(rsp.getForwardedUrl());
+	}
+}


### PR DESCRIPTION
This is a first attempt at fixing the baseUrl global property. It didn't actually work because the FileServlet redirect was only ever performed if the baseUrl was the default value ("owa").

This isn't ideal, since the filter is now being invoked for _all_ URLs, but the only other way I could think of seemed worse. I'm open to suggestions.
