### PR TITLE
📗 Fixed filter to use global property

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
+++ b/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
@@ -14,6 +14,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.owa.AppManager;
 
 /**
  * @author sunbiz
@@ -30,18 +31,21 @@ public class OwaFilter implements Filter {
 	@Override
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
 		HttpServletRequest request = (HttpServletRequest) req;
-		String requestURI = request.getRequestURI();
+		String requestURL = request.getRequestURL().toString();
+		
+		String owaBasePath = Context.getAdministrationService().getGlobalProperty(AppManager.KEY_APP_BASE_URL);
+		
 		if (Context.isAuthenticated()) {
-			if (requestURI.startsWith(openmrsPath + "/owa")) {
-				String newURI = requestURI.replace(openmrsPath + "/owa", "/ms/owa/fileServlet");
-				req.getRequestDispatcher(newURI).forward(req, res);
+			if (requestURL.startsWith(owaBasePath)) {
+				String newURL = requestURL.replace(owaBasePath, "/ms/owa/fileServlet");
+				req.getRequestDispatcher(newURL).forward(req, res);
 			} else {
 				chain.doFilter(req, res);
 			}
 		} else {
-			if (requestURI.startsWith(openmrsPath + "/owa")) {
-				String newURI = requestURI.replace(openmrsPath + "/owa", "/ms/owa/redirectServlet");
-				req.getRequestDispatcher(newURI).forward(req, res);
+			if (requestURL.startsWith(owaBasePath)) {
+				String newURL = requestURL.replace(owaBasePath, "/ms/owa/redirectServlet");
+				req.getRequestDispatcher(newURL).forward(req, res);
 			} else {
 				chain.doFilter(req, res);
 			}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -40,7 +40,7 @@
     </filter>
     <filter-mapping>
         <filter-name>owaFilter</filter-name>
-        <url-pattern>/owa/*</url-pattern>
+        <url-pattern>*</url-pattern>
     </filter-mapping>
 	
     <!-- Maps hibernate file's, if present -->

--- a/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
@@ -1,0 +1,100 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.owa.filter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.owa.AppManager;
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OwaFilterTest extends BaseModuleWebContextSensitiveTest {
+
+	private static String DEFAULT_APP_BASE_URL = "http://localhost:80/openmrs/owa";
+
+	private static String DEFAULT_APP_BASE_URI = "/openmrs/owa";
+
+	private static String SOME_RANDOM_BASE_URL = "http://localhost:80/openmrs/somethingbesidesthedefault";
+
+	private static String SOME_RANDOM_BASE_URI = "/openmrs/somethingbesidesthedefault";
+
+	private static String SOME_PATH_IN_APP = "/anything/index.hml";
+
+	private static String DUMMY_CONTEXT_PATH = "http://localhost:80/openmrs";
+
+	private static String FILE_SERVLET_REDIRECT_URL = "/ms/owa/fileServlet";
+
+	FilterConfig filterConfig;
+
+	ServletContext servletContext;
+
+	public OwaFilterTest() {
+
+	}
+
+	@Before
+	public void setUpMocks() {
+		filterConfig = mock(FilterConfig.class);
+		servletContext = mock(ServletContext.class);
+
+		when(servletContext.getContextPath()).thenReturn(DUMMY_CONTEXT_PATH);
+		when(filterConfig.getServletContext()).thenReturn(servletContext);
+	}
+
+	/**
+	 * Test that the OwaFilter class actually services from the base path defined in the global
+	 * property and ignore any other requests.
+	 */
+	@Test
+	public void testOwaFilterUsesGlobalProperty() throws Exception {
+		OwaFilter owaFilter = new OwaFilter();
+		owaFilter.init(filterConfig);
+
+		MockFilterChain mockFilterChain = new MockFilterChain();
+		MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+		// First make sure that it works with the default base URL
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(AppManager.KEY_APP_BASE_URL, DEFAULT_APP_BASE_URL));
+
+		MockHttpServletRequest req = new MockHttpServletRequest("GET", DEFAULT_APP_BASE_URI + SOME_PATH_IN_APP);
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertEquals(FILE_SERVLET_REDIRECT_URL + SOME_PATH_IN_APP, rsp.getForwardedUrl());
+
+		// Now try a custom base URL
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(AppManager.KEY_APP_BASE_URL, SOME_RANDOM_BASE_URL));
+		mockFilterChain = new MockFilterChain();
+		req = new MockHttpServletRequest("GET", SOME_RANDOM_BASE_URI + SOME_PATH_IN_APP);
+		rsp = new MockHttpServletResponse();
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertEquals(FILE_SERVLET_REDIRECT_URL + SOME_PATH_IN_APP, rsp.getForwardedUrl());
+
+		// Ensure non-OWA base URLs are ignored
+		req = new MockHttpServletRequest("GET",
+				DEFAULT_APP_BASE_URI + SOME_PATH_IN_APP); // we can reuse this URL because the global property has been reset
+		rsp = new MockHttpServletResponse();
+		owaFilter.doFilter(req, rsp, mockFilterChain);
+		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertNull(rsp.getForwardedUrl());
+	}
+}


### PR DESCRIPTION
The baseUrl global property wasn't working because the path it was checking for (and invoked on) was hard coded. The filter is now invoked for every URL and checks programatically using the global property. The solution doesn't seem optimal, so I'm open to suggestions for improvement.
