### PR TITLE
📁 Fix explicit path separator literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 hs_err_pid*
 /api/target/
 /omod/target/
+
+# IntelliJ
+.idea

--- a/omod/src/main/java/org/openmrs/module/owa/activator/OwaActivator.java
+++ b/omod/src/main/java/org/openmrs/module/owa/activator/OwaActivator.java
@@ -1,6 +1,6 @@
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0 + Health disclaimer. If a copy of the MPL was not 
+ * License, v. 2.0 + Health disclaimer. If a copy of the MPL was not
  * distributed with this file, You can obtain one at http://license.openmrs.org
  */
 package org.openmrs.module.owa.activator;
@@ -15,6 +15,7 @@ import org.openmrs.module.ModuleActivator;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
 import org.openmrs.module.owa.AppManager;
 import org.openmrs.util.OpenmrsUtil;
 
@@ -22,9 +23,9 @@ import org.openmrs.util.OpenmrsUtil;
  * This class contains the logic that is run every time this module is either started or stopped.
  */
 public class OwaActivator implements ModuleActivator {
-	
+
 	protected Log log = LogFactory.getLog(getClass());
-	
+
 	/**
 	 * @see ModuleActivator#willRefreshContext()
 	 */
@@ -32,7 +33,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willRefreshContext() {
 		log.info("Refreshing OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#contextRefreshed()
 	 */
@@ -44,7 +45,8 @@ public class OwaActivator implements ModuleActivator {
 		 */
 		String owaAppFolderPath = Context.getAdministrationService().getGlobalProperty(AppManager.KEY_APP_FOLDER_PATH);
 		if (null == owaAppFolderPath) {
-			owaAppFolderPath = OpenmrsUtil.getApplicationDataDirectory() + "owa";
+			owaAppFolderPath = OpenmrsUtil.getApplicationDataDirectory() + (OpenmrsUtil.getApplicationDataDirectory()
+					.endsWith(File.separator) ? "owa" : File.separator + "owa");
 			Context.getAdministrationService().setGlobalProperty(AppManager.KEY_APP_FOLDER_PATH, owaAppFolderPath);
 		}
 		String owaStarted = Context.getAdministrationService().getGlobalProperty("owa.started");
@@ -71,7 +73,7 @@ public class OwaActivator implements ModuleActivator {
 		}
 		log.info("OWA Module refreshed");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#willStart()
 	 */
@@ -79,7 +81,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willStart() {
 		log.info("Starting OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#started()
 	 */
@@ -87,7 +89,7 @@ public class OwaActivator implements ModuleActivator {
 	public void started() {
 		log.info("OWA started");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#willStop()
 	 */
@@ -95,7 +97,7 @@ public class OwaActivator implements ModuleActivator {
 	public void willStop() {
 		log.info("Stopping OWA Module");
 	}
-	
+
 	/**
 	 * @see ModuleActivator#stopped()
 	 */
@@ -103,5 +105,5 @@ public class OwaActivator implements ModuleActivator {
 	public void stopped() {
 		log.info("OWA Module stopped");
 	}
-	
+
 }

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/AddAppControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/AddAppControllerTest.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.net.URL;
 
 import javax.servlet.http.HttpServletRequest;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,28 +24,28 @@ import org.springframework.mock.web.MockServletContext;
  * @author sunbiz
  */
 public class AddAppControllerTest extends BaseModuleWebContextSensitiveTest {
-	
+
 	MessageSourceService originalMessageSourceService;
-	
+
 	MessageSourceService messageSourceService;
-	
+
 	public AddAppControllerTest() {
-		
+
 	}
-	
+
 	@Before
 	public void setUpMockMessageSourceService() {
 		originalMessageSourceService = ServiceContext.getInstance().getMessageSourceService();
 		messageSourceService = Mockito.mock(MessageSourceService.class);
 	}
-	
+
 	@After
 	public void restoreOriginalMessageSourceService() {
 		if (originalMessageSourceService != null) {
 			ServiceContext.getInstance().setMessageSourceService(originalMessageSourceService);
 		}
 	}
-	
+
 	/**
 	 * Test of upload method, of class AddAppController.
 	 */
@@ -57,36 +58,38 @@ public class AddAppControllerTest extends BaseModuleWebContextSensitiveTest {
 		controller.upload(multifile, request);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void testUploadofEmptyZipFile() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/module/owa/addApp.htm");
-		FileInputStream file = new FileInputStream(new File("src/test/resources/Blank_Zip.zip"));
+		FileInputStream file = new FileInputStream(
+				new File("src/test/resources/Blank_Zip.zip".replace("/", File.separator)));
 		MockMultipartFile multifile = new MockMultipartFile("testFile", "Blank_Zip.zip", null, file);
 		AddAppController controller = (AddAppController) applicationContext.getBean("addAppController");
 		controller.upload(multifile, request);
 		Assert.assertEquals("owa.blank_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void testUploadofZipFilewithoutManifest() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/module/owa/addApp.htm");
-		FileInputStream file = new FileInputStream(new File("src/test/resources/Zipwithoutmanifest.zip"));
+		FileInputStream file = new FileInputStream(new File("src/test/resources/Zipwithoutmanifest.zip".replace("/",
+				File.separator)));
 		MockMultipartFile multifile = new MockMultipartFile("testFile", "Zipwithoutmanifest.zip", "application/zip,.zip",
-		        file);
+				file);
 		AddAppController controller = (AddAppController) applicationContext.getBean("addAppController");
 		controller.upload(multifile, request);
 		Assert.assertEquals("owa.manifest_not_found", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void testUploadofZipFilewithProperManifest() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/module/owa/addApp.htm");
-		FileInputStream file = new FileInputStream(new File("src/test/resources/designer.zip"));
+		FileInputStream file = new FileInputStream(new File("src/test/resources/designer.zip".replace("/", File.separator)));
 		MockMultipartFile multifile = new MockMultipartFile("testFile", "designer.zip", "application/zip,.zip", file);
 		AddAppController controller = (AddAppController) applicationContext.getBean("addAppController");
 		controller.upload(multifile, request);
 		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
 	}
-	
+
 }

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
@@ -24,47 +24,47 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockServletContext;
 
 public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
-	
+
 	MessageSourceService originalMessageSourceService;
-	
+
 	MessageSourceService messageSourceService;
-	
+
 	public OwaRestControllerTest() {
-		
+
 	}
-	
+
 	@Before
 	public void setUpMockMessageSourceService() {
 		originalMessageSourceService = ServiceContext.getInstance().getMessageSourceService();
 		messageSourceService = Mockito.mock(MessageSourceService.class);
 	}
-	
+
 	@After
 	public void restoreOriginalMessageSourceService() {
 		if (originalMessageSourceService != null) {
 			ServiceContext.getInstance().setMessageSourceService(originalMessageSourceService);
 		}
 	}
-	
+
 	@Test
 	public void getAppList_shouldNotReturnNull() throws Exception {
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		Assert.assertNotNull(controller.getAppList());
 	}
-	
+
 	@Test
 	public void getSettings_shouldNotReturnNull() throws Exception {
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		Assert.assertNotNull(controller.getSettings());
 	}
-	
+
 	@Test
 	public void updateSettings_shouldNotReturnNull() throws Exception {
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		List<GlobalProperty> settings = Context.getAdministrationService().getGlobalProperties();
 		Assert.assertNotNull(controller.updateSettings(settings));
 	}
-	
+
 	/**
 	 * OwaRestController upload method test casing.
 	 */
@@ -72,41 +72,43 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void upload_caseNotAZipFile() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/addapp");
 		HttpServletResponse response = new MockHttpServletResponse();
-		FileInputStream file = new FileInputStream(new File("src/test/resources/testing"));
+		FileInputStream file = new FileInputStream(new File("src/test/resources/testing".replace("/", File.separator)));
 		MockMultipartFile mmf = new MockMultipartFile("nonZipFile", "testing", null, file);
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		controller.upload(mmf, request, response);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void upload_caseEmptyZipFile() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/addapp");
 		HttpServletResponse response = new MockHttpServletResponse();
-		FileInputStream file = new FileInputStream(new File("src/test/resources/Blank_Zip.zip"));
+		FileInputStream file = new FileInputStream(
+				new File("src/test/resources/Blank_Zip.zip".replace("/", File.separator)));
 		MockMultipartFile mmf = new MockMultipartFile("emptyZipFile", "Blank_Zip.zip", null, file);
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		controller.upload(mmf, request, response);
 		Assert.assertEquals("owa.blank_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void upload_caseZipFileWithoutManifest() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/addapp");
 		HttpServletResponse response = new MockHttpServletResponse();
-		FileInputStream file = new FileInputStream(new File("src/test/resources/Zipwithoutmanifest.zip"));
+		FileInputStream file = new FileInputStream(new File("src/test/resources/Zipwithoutmanifest.zip".replace("/",
+				File.separator)));
 		MockMultipartFile mmf = new MockMultipartFile("zipFileNoManifest", "Zipwithoutmanifest.zip", "application/zip,.zip",
-		        file);
+				file);
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		controller.upload(mmf, request, response);
 		Assert.assertEquals("owa.manifest_not_found", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-	
+
 	@Test
 	public void upload_caseProperZipFile() throws Exception {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/addapp");
 		HttpServletResponse response = new MockHttpServletResponse();
-		FileInputStream file = new FileInputStream(new File("src/test/resources/designer.zip"));
+		FileInputStream file = new FileInputStream(new File("src/test/resources/designer.zip".replace("/", File.separator)));
 		MockMultipartFile multifile = new MockMultipartFile("properZipFile", "designer.zip", "application/zip,.zip", file);
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		controller.upload(multifile, request, response);


### PR DESCRIPTION
This fixes the issue with the default `appdata` directory and fixes up some path separator literals in the tests.
