### PR TITLE
Replace ant-compress with zip4j

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,8 +51,8 @@
 				
         <!-- End OpenMRS core -->
         <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-compress</artifactId>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
         </dependency>
     </dependencies>
 	

--- a/omod/src/main/java/org/openmrs/module/owa/impl/DefaultAppManager.java
+++ b/omod/src/main/java/org/openmrs/module/owa/impl/DefaultAppManager.java
@@ -27,7 +27,7 @@
  */
 package org.openmrs.module.owa.impl;
 
-import org.apache.ant.compress.taskdefs.Unzip;
+import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.map.DeserializationConfig;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.openmrs.GlobalProperty;
+import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.owa.App;
 import org.openmrs.module.owa.AppManager;
@@ -108,10 +109,12 @@ public class DefaultAppManager implements AppManager {
 
 				String dest = getAppFolderPath() + File.separator + deployedName;
 
-				Unzip unzip = new Unzip();
-				unzip.setSrc(file);
-				unzip.setDest(new File(dest));
-				unzip.execute();
+				try {
+					net.lingala.zip4j.core.ZipFile zipFile = new net.lingala.zip4j.core.ZipFile(file);
+					zipFile.extractAll(dest);
+				} catch (ZipException e) {
+					throw new APIException(e.getMessage(), e);
+				}
 
 				// ---------------------------------------------------------------------
 				// Set openmrs server location

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant-compress</artifactId>
-                <version>1.4</version>
-                <type>jar</type>
+                <groupId>net.lingala.zip4j</groupId>
+                <artifactId>zip4j</artifactId>
+                <version>1.3.2</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Apache ant-compress requires java8 to build hence making builds to fail
when running on java7. This makes it impossible to install apps when the module
is running on platform 1.9.x since it's running on java7