### PR TITLE
OWA-18 : Fixed 404 not found error

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaManageController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaManageController.java
@@ -95,13 +95,14 @@ public class OwaManageController {
 	}
 	
 	@ModelAttribute("appBaseUrl")
-	public String getAppBaseUrl() {
+	public String getAppBaseUrl(HttpServletRequest request) {
+		String serverContext = request.getContextPath();
 		String owaBasePath = Context.getAdministrationService().getGlobalProperty(AppManager.KEY_APP_BASE_URL,
 		    OwaFilter.DEFAULT_BASE_URL);
 		if (OwaFilter.isFullBasePath(owaBasePath)) {
 			return owaBasePath;
 		} else {
-			return "/openmrs" + owaBasePath;
+			return serverContext + owaBasePath;
 		}
 	}
 


### PR DESCRIPTION
Fixed the "404 not found error" (in case of deploying webapp through "openmrs-standalone platform") by adding conditions on server context through "HttpServletRequest.getContextPath()" interface.

link to the issue : https://issues.openmrs.org/browse/OWA-18