### PR TITLE
OWA-66: Extend endpoint to accept filename request body

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
@@ -3,7 +3,9 @@ package org.openmrs.module.owa.web.controller;
 public class InstallAppRequestObject {
 	
 	private String urlValue;
-	
+
+	private String fileName;
+
 	public InstallAppRequestObject() {
 	}
 	
@@ -11,7 +13,16 @@ public class InstallAppRequestObject {
 		this.urlValue = urlValue;
 	}
 	
+	public InstallAppRequestObject(String urlValue, String fileName) {
+		this.urlValue = urlValue;
+		this.fileName = fileName;
+	}
+
 	public String getUrlValue() {
-		return this.urlValue;
+		return urlValue;
+	}
+	
+	public String getFileName() {
+		return fileName;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
@@ -163,7 +163,7 @@ public class OwaRestController {
 				if (!url.isEmpty()) {
 					InputStream inputStream = ModuleUtil.getURLStream(downloadUrl);
 					log.warn("url pathname: " + downloadUrl.getPath());
-					String fileName = downloadUrl.getQuery().substring(downloadUrl.getQuery().lastIndexOf("=") + 1);
+					String fileName = urlObject.getFileName() != null ? urlObject.getFileName() + ".zip" : downloadUrl.getQuery().substring(downloadUrl.getQuery().lastIndexOf("=") + 1);
 					File file = ModuleUtil.insertModuleFile(inputStream, fileName);
 					try (ZipFile zip = new ZipFile(file)) {
 						if (zip.size() == 0) {

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
@@ -138,4 +138,15 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		List<App> appList = controller.install(requestData, request, response);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
+	
+	@Test
+	public void install_rightDownloadUrl_withFileName() throws Exception {
+		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/installapp");
+		HttpServletResponse response = new MockHttpServletResponse();
+		String downloadUrl = "https://bintray.com/openmrs/owa/download_file?file_path=cohortbuilder-1.0.0-beta.zip";
+		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl, "Cohort Builder OWA");
+		List<App> appList = controller.install(requestData, request, response);
+		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+	}
 }


### PR DESCRIPTION
## JIRA TICKET NAME: [Extend endpoint to accept filename request body](https://issues.openmrs.org/browse/OWA-66)

### SUMMARY:
The previous implementation uses hacks to get the filename from the download url by splitting it into segments, then extracting the necessary segment. This hack is inconsistent as the download url varies from one open web app to another, hence, an inconsistency in the file name produced. 

This implementation extracts the name of the file from the client and uses it in the installation of the open web apps.