### PR TITLE
OWA-68: Re-installation of previously removed OWA's give error

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
@@ -4,6 +4,8 @@ public class InstallAppRequestObject {
 	
 	private String urlValue;
 	
+	private String fileName;
+	
 	public InstallAppRequestObject() {
 	}
 	
@@ -11,7 +13,16 @@ public class InstallAppRequestObject {
 		this.urlValue = urlValue;
 	}
 	
+	public InstallAppRequestObject(String urlValue, String fileName) {
+		this.urlValue = urlValue;
+		this.fileName = fileName;
+	}
+	
 	public String getUrlValue() {
-		return this.urlValue;
+		return urlValue;
+	}
+	
+	public String getFileName() {
+		return fileName;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaManageController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaManageController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +52,8 @@ public class OwaManageController {
 	}
 	
 	@RequestMapping(value = "/deleteApp", method = RequestMethod.GET)
-	public String deleteApp(@RequestParam("appName") String appName, @RequestParam(value= "returnURL", required = false) String returnURL, ModelMap model) {
+	public String deleteApp(@RequestParam("appName") String appName,
+	        @RequestParam(value = "returnURL", required = false) String returnURL, ModelMap model) {
 		if (appName != null && Context.hasPrivilege("Manage OWA")) {
 			appManager.deleteApp(appName);
 			model.clear();

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
@@ -138,4 +138,15 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		List<App> appList = controller.install(requestData, request, response);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
+	
+	@Test
+	public void install_rightDownloadUrl_withFileName() throws Exception {
+		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/installapp");
+		HttpServletResponse response = new MockHttpServletResponse();
+		String downloadUrl = "https://bintray.com/openmrs/owa/download_file?file_path=cohortbuilder-1.0.0-beta.zip";
+		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl, "Cohort Builder OWA");
+		List<App> appList = controller.install(requestData, request, response);
+		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+	}
 }


### PR DESCRIPTION
## JIRA TICKET NAME:
[OWA-68: Re-installation of previously removed OWA's give error](https://issues.openmrs.org/browse/OWA-68)

## SUMMARY:
When an OWA that was previously installed on the system but was deleted tries to be re-installed, it returns an error that the module already exists and fails to install it.