### PR TITLE
OWA-69 : Endpoint to get the allow web admin properties on the Addon …

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
@@ -218,4 +218,10 @@ public class OwaRestController {
 		}
 		return appList;
 	}
+
+	@RequestMapping(value = "/rest/owa/allowModuleWebUpload", method = RequestMethod.GET)
+	@ResponseBody
+	public boolean allowWebAdmin(HttpServletRequest request, HttpServletResponse response) {
+		 return ModuleUtil.allowAdmin();
+	}
 }

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
@@ -9,6 +9,7 @@ import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.ServiceContext;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.owa.App;
 import org.openmrs.module.owa.AppManager;
 import org.openmrs.web.WebConstants;
@@ -137,5 +138,17 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl, "Cohort Builder OWA");
 		List<App> appList = controller.install(requestData, request, response);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
+	}
+
+	@Test
+	public void allowWebAdmin_shouldNotReturnNull() {
+		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "GET",
+		        "/rest/owa/allowModuleWebUpload");
+		HttpServletResponse response = new MockHttpServletResponse();
+		boolean allowModuleWebUpload = ModuleUtil.allowAdmin();
+		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
+		boolean allowAdmin = controller.allowWebAdmin(request, response);
+		Assert.assertNotNull(allowAdmin);
+		Assert.assertEquals(allowModuleWebUpload, allowAdmin);
 	}
 }


### PR DESCRIPTION
### JIRA TICKET NAME:
[OWA-69 : Endpoint to get the allow web admin properties on the Addon manager module.](https://issues.openmrs.org/browse/OWA-69)

#### Summary : 
this ticket seeks to create an endpoint to get the read-only value.
The endpoint is to be used on the Add-on manager so as to restrict admin priviledges if it is set to false.