### PR TITLE
OWA-70: Fix generated owa url after installation of OWA

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -18,3 +18,5 @@ ${project.parent.artifactId}.saved=Global Properties Saved
 ${project.parent.artifactId}.appBaseUrl.label = App Base URL
 ${project.parent.artifactId}.appFolderPath.label = App Folder Path
 ${project.parent.artifactId}.appStoreUrl.label = App Store URL
+${project.parent.artifactId}.invalid_owa_Url = The file path to the OWA is invalid. It should lead to a downloadable OWA zip file
+${project.parent.artifactId}.missing_owa_file = OWA file to be installed, is not specified in the file path.

--- a/omod/src/main/java/org/openmrs/module/owa/utils/OwaUtils.java
+++ b/omod/src/main/java/org/openmrs/module/owa/utils/OwaUtils.java
@@ -1,0 +1,47 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0 + Health disclaimer. If a copy of the MPL was not distributed with
+ * this file, You can obtain one at http://license.openmrs.org
+ */
+package org.openmrs.module.owa.utils;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * This class contains utility methods that support various actions that affect OWAs
+ * for example OWA installation
+ */
+public class OwaUtils {
+
+	/**
+	 * Gets the file name from the OWA installation url
+	 *
+	 * @param installUrl URL to where the OWA zip can be downloaded
+	 * @return the file name of the owa
+	 */
+	public static String getFileName(String installUrl) {
+		String passedFileName = null;
+		if (installUrl.contains("file_path=")) {
+			passedFileName = StringUtils.substringBetween(installUrl, "file_path=", ".zip");
+		} else {
+			passedFileName = FilenameUtils.getName(installUrl);
+		}
+		return removeVersionNumber(passedFileName);
+	}
+
+	/**
+	 * Removes the version number from the file name of the OWA
+	 *
+	 * @param passedFileName File name of owa that may contain owa version number
+	 * @return the file name of the owa with the version number removed
+	 */
+	public static String removeVersionNumber(String passedFileName) {
+		String[] tokens = passedFileName.split("((-|[_])+[0-9])|[\\s]");
+		String fileName = tokens[0];
+		if (fileName != null && !fileName.contains(".zip")) {
+			fileName += ".zip";
+		}
+		return fileName;
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
@@ -3,22 +3,15 @@ package org.openmrs.module.owa.web.controller;
 public class InstallAppRequestObject {
 
 	private String urlValue;
-	
-	private String fileName;
 
 	public InstallAppRequestObject() {
 	}
 
-	public InstallAppRequestObject(String urlValue, String fileName) {
+	public InstallAppRequestObject(String urlValue) {
 		this.urlValue = urlValue;
-		this.fileName = fileName;
 	}
 
 	public String getUrlValue() {
 		return urlValue;
-	}
-
-	public String getFileName() {
-		return fileName;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
@@ -6,6 +6,7 @@ package org.openmrs.module.owa.web.controller;
  * this file, You can obtain one at http://license.openmrs.org
  */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -17,7 +18,6 @@ import java.util.zip.ZipFile;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
@@ -28,6 +28,8 @@ import org.openmrs.module.owa.App;
 import org.openmrs.module.owa.AppManager;
 import org.openmrs.web.WebConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +38,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
+
+import org.openmrs.module.owa.utils.OwaUtils;
 
 /**
  * @author Saptarshi Purkayastha
@@ -108,7 +112,7 @@ public class OwaRestController {
 			String message;
 			HttpSession session = request.getSession();
 			if (!file.isEmpty()) {
-				String fileName = file.getOriginalFilename();
+				String fileName = OwaUtils.removeVersionNumber(file.getOriginalFilename());
 				File uploadedFile = new File(file.getOriginalFilename());
 				file.transferTo(uploadedFile);
 				try (ZipFile zip = new ZipFile(uploadedFile)) {
@@ -151,77 +155,92 @@ public class OwaRestController {
 
 	@RequestMapping(value = "/rest/owa/installapp", method = RequestMethod.POST)
 	@ResponseBody
-	public List<App> install(@RequestBody InstallAppRequestObject urlObject, HttpServletRequest request, HttpServletResponse response) throws IOException {
+	public ResponseEntity<List<App>> install(@RequestBody InstallAppRequestObject urlObject,
+	        HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String message;
+		String fileName = null;
 		List<App> appList = new ArrayList<>();
+		Boolean checkInstall = false;
 
-		String url = urlObject.getUrlValue();
-		String fileName = urlObject.getFileName();
-		if(fileName == null || fileName == ""){
-			throw new  NullPointerException(
-				"File name must be passed for installation"
-			);
-		}
-		URL downloadUrl = null;
-		if (ResourceUtils.isUrl(url)) {
-			downloadUrl = new URL(url);
-		}
 		if (Context.hasPrivilege("Manage OWA")) {
-			String message;
 			HttpSession session = request.getSession();
-			if (!url.isEmpty()) {
+			URL downloadUrl = null;
+			String installUrl = urlObject.getUrlValue();
+
+			if (!installUrl.contains(".zip")) {
+				message = messageSourceService.getMessage("owa.invalid_owa_Url");
+				log.warn("Invalid URL to OWA download. The URL is expected to link to a zip file");
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+				response.sendError(400, message);
+				return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
+			}
+
+			try {
+				downloadUrl = ResourceUtils.getURL(installUrl);
+				fileName = OwaUtils.getFileName(installUrl);
+				if (fileName == null || fileName.isEmpty()) {
+					message = messageSourceService.getMessage("owa.missing_owa_file");
+					log.warn("No specified download file in Installation URL");
+					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+					response.sendError(400, message);
+					return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
+				}
 				InputStream inputStream = ModuleUtil.getURLStream(downloadUrl);
 				log.info("Url pathname: " + downloadUrl.getPath());
-				fileName += ".zip";
-				final String fileMatch=  fileName;
 				File file = ModuleUtil.insertModuleFile(inputStream, fileName);
-				try (ZipFile zip = new ZipFile(file)) {
+
+				try(ZipFile zip = new ZipFile(file)){
 					if (zip.size() == 0) {
 						message = messageSourceService.getMessage("owa.blank_zip");
-						file.delete();
 						log.warn("Zip file is empty");
 						session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-						response.sendError(500, message);
+						response.sendError(400, message);
+						file.delete();
+						return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
 					} else {
 						ZipEntry entry = zip.getEntry("manifest.webapp");
 						if (entry == null) {
 							message = messageSourceService.getMessage("owa.manifest_not_found");
 							log.warn("Manifest file could not be found in app");
-							file.delete();
 							session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-							response.sendError(500, message);
+							response.sendError(400, message);
+							file.delete();
+							return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
 						} else {
 							String contextPath = request.getScheme() + "://" + request.getServerName() + ":"
 									+ request.getServerPort() + request.getContextPath();
 							appManager.installApp(file, fileName, contextPath);
-							file.delete();
 							message = messageSourceService.getMessage("owa.app_installed");
 							response.setStatus(200);
+							file.delete();
 							session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, message);
+							appManager.reloadApps();
+							appList = appManager.getApps();
+							return new ResponseEntity<List<App>>(appList, HttpStatus.OK);
 						}
 					}
-				}
-				catch (Exception e) {
+				}catch(Exception e){
 					message = messageSourceService.getMessage("owa.not_a_zip");
 					log.warn("App is not a zip archive");
 					file.delete();
 					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-					response.sendError(500, message);
+					response.sendError(400, message);
+					return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
 				}
-			} else {
-				message = messageSourceService.getMessage("owa.invalid_url");
-				log.warn("Invalid url");
-				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-				response.sendError(400, message);
 			}
-			appManager.reloadApps();
-			appList = appManager.getApps();
+			catch (FileNotFoundException e) {
+				log.warn(e.getMessage());
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, e.getMessage());
+				response.sendError(400, e.getMessage());
+				return new ResponseEntity<List<App>>(HttpStatus.BAD_REQUEST);
+			}
 		}
-		return appList;
+		return new ResponseEntity<List<App>>(HttpStatus.FORBIDDEN);
 	}
 
 	@RequestMapping(value = "/rest/owa/allowModuleWebUpload", method = RequestMethod.GET)
 	@ResponseBody
-	public boolean allowWebAdmin(HttpServletRequest request, HttpServletResponse response) {
-		 return ModuleUtil.allowAdmin();
+	public Boolean allowWebAdmin(HttpServletRequest request, HttpServletResponse response) {
+		return ModuleUtil.allowAdmin();
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/owa/utils/OwaUtilsTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/utils/OwaUtilsTest.java
@@ -1,0 +1,29 @@
+package org.openmrs.module.owa.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OwaUtilsTest {
+	
+	@Test
+	public void testgetFileNameWithNoQueryString() {
+		String testString = "https://dl.bintray.com/openmrs/owa/cohortbuilder-1.0.0-beta.zip";
+		String fileName = OwaUtils.getFileName(testString);
+		Assert.assertEquals(fileName, "cohortbuilder.zip");
+	}
+	
+	@Test
+	public void testgetFileNameWithQueryString() {
+		String testString = "https://bintray.com/openmrs/owa/download_file?file_path=cohortbuilder-1.0.0-beta.zip";
+		String fileName = OwaUtils.getFileName(testString);
+		Assert.assertEquals(fileName, "cohortbuilder.zip");
+	}
+	
+	@Test
+	public void testRemoveVersionNumber() {
+		String testString = "cohortbuilder-1.0.0-beta.zip";
+		String fileName = OwaUtils.removeVersionNumber(testString);
+		Assert.assertEquals(fileName, "cohortbuilder.zip");
+	}
+	
+}

--- a/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/web/controller/OwaRestControllerTest.java
@@ -14,6 +14,7 @@ import org.openmrs.module.owa.App;
 import org.openmrs.module.owa.AppManager;
 import org.openmrs.web.WebConstants;
 import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockMultipartFile;
@@ -112,7 +113,8 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/addapp");
 		HttpServletResponse response = new MockHttpServletResponse();
 		FileInputStream file = new FileInputStream(new File("src/test/resources/designer.zip".replace("/", File.separator)));
-		MockMultipartFile multifile = new MockMultipartFile("properZipFile", "designer.zip", "application/zip,.zip", file);
+		MockMultipartFile multifile = new MockMultipartFile("properZipFile", "designer-1.0.0.zip", "application/zip,.zip",
+		        file);
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
 		controller.upload(multifile, request, response);
 		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
@@ -124,8 +126,8 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		HttpServletResponse response = new MockHttpServletResponse();
 		String downloadUrl = "https://bintray.com/openmrs/owa/download_file?file_path=cohortbuilder-1.0.0-beta.zip";
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
-		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl, "Cohort Builder OWA");
-		List<App> appList = controller.install(requestData, request, response);
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl);
+		ResponseEntity<List<App>> appList = controller.install(requestData, request, response);
 		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
 	}
 	
@@ -135,11 +137,33 @@ public class OwaRestControllerTest extends BaseModuleWebContextSensitiveTest {
 		HttpServletResponse response = new MockHttpServletResponse();
 		String downloadUrl = "https://bintray.com/openmrs/owa/download_file?file_path=notAZip.zip";
 		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
-		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl, "Cohort Builder OWA");
-		List<App> appList = controller.install(requestData, request, response);
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl);
+		ResponseEntity<List<App>> appList = controller.install(requestData, request, response);
 		Assert.assertEquals("owa.not_a_zip", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
-
+	
+	@Test
+	public void install_missingFilePath() throws Exception {
+		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/installapp");
+		HttpServletResponse response = new MockHttpServletResponse();
+		String downloadUrl = "https://bintray.com/openmrs/owa/download_file";
+		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl);
+		ResponseEntity<List<App>> appList = controller.install(requestData, request, response);
+		Assert.assertEquals("owa.invalid_owa_Url", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
+	}
+	
+	@Test
+	public void install_urlEndsWithFileName() throws Exception {
+		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "POST", "/rest/owa/installapp");
+		HttpServletResponse response = new MockHttpServletResponse();
+		String downloadUrl = "https://dl.bintray.com/openmrs/owa/cohortbuilder-1.0.0-beta.zip";
+		OwaRestController controller = (OwaRestController) applicationContext.getBean("owaRestController");
+		InstallAppRequestObject requestData = new InstallAppRequestObject(downloadUrl);
+		ResponseEntity<List<App>> appList = controller.install(requestData, request, response);
+		Assert.assertEquals("owa.app_installed", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+	}
+	
 	@Test
 	public void allowWebAdmin_shouldNotReturnNull() {
 		HttpServletRequest request = new MockHttpServletRequest(new MockServletContext(), "GET",


### PR DESCRIPTION
## JIRA TICKET NAME:
[OWA-70: Fix generated owa url after installation of OWA](https://issues.openmrs.org/browse/OWA-70)

## SUMMARY:
Make the url that is generated after the installation of the owa uniform. As of now, it takes on either the name of the OWA which can have spaces in it, or the name of the bundled file that is meant to have version numbers that change as newer versions come in.