### PR TITLE
OWA-70: Fix generated owa url after installation of OWA

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/InstallAppRequestObject.java
@@ -3,22 +3,15 @@ package org.openmrs.module.owa.web.controller;
 public class InstallAppRequestObject {
 
 	private String urlValue;
-	
-	private String fileName;
 
 	public InstallAppRequestObject() {
 	}
 
-	public InstallAppRequestObject(String urlValue, String fileName) {
+	public InstallAppRequestObject(String urlValue) {
 		this.urlValue = urlValue;
-		this.fileName = fileName;
 	}
 
 	public String getUrlValue() {
 		return urlValue;
-	}
-
-	public String getFileName() {
-		return fileName;
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
+++ b/omod/src/main/java/org/openmrs/module/owa/web/controller/OwaRestController.java
@@ -6,6 +6,7 @@ package org.openmrs.module.owa.web.controller;
  * this file, You can obtain one at http://license.openmrs.org
  */
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -17,7 +18,8 @@ import java.util.zip.ZipFile;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
@@ -28,6 +30,8 @@ import org.openmrs.module.owa.App;
 import org.openmrs.module.owa.AppManager;
 import org.openmrs.web.WebConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,18 +51,18 @@ import org.springframework.web.multipart.MultipartFile;
 @Deprecated
 @Controller
 public class OwaRestController {
-
+	
 	private static final Log log = LogFactory.getLog(OwaRestController.class);
-
+	
 	// -------------------------------------------------------------------------
 	// Dependencies
 	// -------------------------------------------------------------------------
 	@Autowired
 	private AppManager appManager;
-
+	
 	@Autowired
 	private MessageSourceService messageSourceService;
-
+	
 	// -------------------------------------------------------------------------
 	// REST implementation
 	// -------------------------------------------------------------------------
@@ -72,7 +76,7 @@ public class OwaRestController {
 		}
 		return appList;
 	}
-
+	
 	@RequestMapping(value = "/rest/owa/settings", method = RequestMethod.GET)
 	@ResponseBody
 	public List<GlobalProperty> getSettings() {
@@ -84,7 +88,7 @@ public class OwaRestController {
 		}
 		return owaSettings;
 	}
-
+	
 	@RequestMapping(value = "/rest/owa/settings", method = RequestMethod.POST)
 	@ResponseBody
 	public List<GlobalProperty> updateSettings(List<GlobalProperty> settings) {
@@ -99,129 +103,140 @@ public class OwaRestController {
 		}
 		return owaSettings;
 	}
-
+	
 	@RequestMapping(value = "/rest/owa/addapp", method = RequestMethod.POST)
 	@ResponseBody
-	public List<App> upload(@RequestParam("file") MultipartFile file, HttpServletRequest request, HttpServletResponse response) throws IOException {
-		List<App> appList = new ArrayList<>();
-		if(Context.hasPrivilege("Manage OWA")){
-			String message;
+	public Boolean upload(@RequestParam("file") MultipartFile file, HttpServletRequest request, HttpServletResponse response)
+	        throws IOException {
+		if (Context.hasPrivilege("Manage OWA")) {
 			HttpSession session = request.getSession();
+			boolean checkInstall = false;
 			if (!file.isEmpty()) {
-				String fileName = file.getOriginalFilename();
-				File uploadedFile = new File(file.getOriginalFilename());
+				String passedFileName = file.getOriginalFilename();
+				String fileName = getFileName(passedFileName);
+				File uploadedFile = new File(fileName);
 				file.transferTo(uploadedFile);
-				try (ZipFile zip = new ZipFile(uploadedFile)) {
-					if (zip.size() == 0) {
-						message = messageSourceService.getMessage("owa.blank_zip");
-						uploadedFile.delete();
-						log.warn("Zip file is empty");
-						session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-						response.sendError(500, message);
-					} else {
-						ZipEntry entry = zip.getEntry("manifest.webapp");
-						if (entry == null) {
-							message = messageSourceService.getMessage("owa.manifest_not_found");
-							log.warn("Manifest file could not be found in app");
-							uploadedFile.delete();
-							session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-							response.sendError(500, message);
-						} else {
-							String contextPath = request.getScheme() + "://" + request.getServerName() + ":"
-									+ request.getServerPort() + request.getContextPath();
-							appManager.installApp(uploadedFile, fileName, contextPath);
-							uploadedFile.delete();
-							message = messageSourceService.getMessage("owa.app_installed");
-							session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, message);
-						}
-					}
-				} catch (Exception e) {
-					message = messageSourceService.getMessage("owa.not_a_zip");
-					log.warn("App is not a zip archive");
-					uploadedFile.delete();
-					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-					response.sendError(500, message);
-				}
+				checkInstall = this.installApp(uploadedFile, fileName, request, response, session);
 			}
 			appManager.reloadApps();
-			appList = appManager.getApps();
+			return checkInstall;
 		}
-		return appList;
+		return false;
 	}
-
+	
 	@RequestMapping(value = "/rest/owa/installapp", method = RequestMethod.POST)
 	@ResponseBody
-	public List<App> install(@RequestBody InstallAppRequestObject urlObject, HttpServletRequest request, HttpServletResponse response) throws IOException {
-		List<App> appList = new ArrayList<>();
-
-		String url = urlObject.getUrlValue();
-		String fileName = urlObject.getFileName();
-		if(fileName == null || fileName == ""){
-			throw new  NullPointerException(
-				"File name must be passed for installation"
-			);
-		}
-		URL downloadUrl = null;
-		if (ResourceUtils.isUrl(url)) {
-			downloadUrl = new URL(url);
-		}
+	public ResponseEntity<? extends Object> install(@RequestBody InstallAppRequestObject urlObject,
+	        HttpServletRequest request, HttpServletResponse response) throws IOException {
+		String message;
+		String fileName = null;
+		
 		if (Context.hasPrivilege("Manage OWA")) {
-			String message;
 			HttpSession session = request.getSession();
-			if (!url.isEmpty()) {
-				InputStream inputStream = ModuleUtil.getURLStream(downloadUrl);
-				log.info("Url pathname: " + downloadUrl.getPath());
-				fileName += ".zip";
-				final String fileMatch=  fileName;
-				File file = ModuleUtil.insertModuleFile(inputStream, fileName);
-				try (ZipFile zip = new ZipFile(file)) {
-					if (zip.size() == 0) {
-						message = messageSourceService.getMessage("owa.blank_zip");
-						file.delete();
-						log.warn("Zip file is empty");
-						session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-						response.sendError(500, message);
-					} else {
-						ZipEntry entry = zip.getEntry("manifest.webapp");
-						if (entry == null) {
-							message = messageSourceService.getMessage("owa.manifest_not_found");
-							log.warn("Manifest file could not be found in app");
-							file.delete();
-							session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-							response.sendError(500, message);
-						} else {
-							String contextPath = request.getScheme() + "://" + request.getServerName() + ":"
-									+ request.getServerPort() + request.getContextPath();
-							appManager.installApp(file, fileName, contextPath);
-							file.delete();
-							message = messageSourceService.getMessage("owa.app_installed");
-							response.setStatus(200);
-							session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, message);
-						}
-					}
-				}
-				catch (Exception e) {
-					message = messageSourceService.getMessage("owa.not_a_zip");
-					log.warn("App is not a zip archive");
-					file.delete();
-					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
-					response.sendError(500, message);
-				}
-			} else {
-				message = messageSourceService.getMessage("owa.invalid_url");
-				log.warn("Invalid url");
+			URL downloadUrl = null;
+			String installUrl = urlObject.getUrlValue();
+			
+			if (!installUrl.contains(".zip")) {
+				message = messageSourceService.getMessage("Invalid URL");
+				log.warn("Invalid URL to OWA download");
 				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
 				response.sendError(400, message);
+				return new ResponseEntity<Boolean>(Boolean.FALSE, HttpStatus.BAD_REQUEST);
 			}
-			appManager.reloadApps();
-			appList = appManager.getApps();
+			
+			try {
+				downloadUrl = ResourceUtils.getURL(installUrl);
+				fileName = getPassedFileName(installUrl);
+				if (fileName == null || fileName.isEmpty()) {
+					message = messageSourceService.getMessage("Installation URL doesnot specify download file");
+					log.warn("No specified download file in Installation URL");
+					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+					response.sendError(400, message);
+					return new ResponseEntity<Boolean>(Boolean.FALSE, HttpStatus.BAD_REQUEST);
+				}
+				InputStream inputStream = ModuleUtil.getURLStream(downloadUrl);
+				log.info("Url pathname: " + downloadUrl.getPath());
+				File file = ModuleUtil.insertModuleFile(inputStream, fileName);
+				Boolean checkInstall = this.installApp(file, fileName, request, response, session);
+				appManager.reloadApps();
+				if (checkInstall)
+					return new ResponseEntity<Boolean>(checkInstall, HttpStatus.OK);
+				return new ResponseEntity<Boolean>(checkInstall, HttpStatus.valueOf(500));
+			}
+			catch (FileNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+				log.warn(e.getMessage());
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, e.getMessage());
+				response.sendError(400, e.getMessage());
+				return new ResponseEntity<Boolean>(Boolean.FALSE, HttpStatus.BAD_REQUEST);
+			}
 		}
-		return appList;
+		return new ResponseEntity<Boolean>(Boolean.FALSE, HttpStatus.UNAUTHORIZED);
 	}
-
+	
 	@RequestMapping(value = "/rest/owa/allowModuleWebUpload", method = RequestMethod.GET)
 	@ResponseBody
-	public boolean allowWebAdmin(HttpServletRequest request, HttpServletResponse response) {
-		 return ModuleUtil.allowAdmin();
+	public Boolean allowWebAdmin(HttpServletRequest request, HttpServletResponse response) {
+		return ModuleUtil.allowAdmin();
+	}
+	
+	private Boolean installApp(File file, String fileName, HttpServletRequest request,
+		HttpServletResponse response, HttpSession session) throws IOException{
+		String message = null;
+		try (ZipFile zip = new ZipFile(file)) {
+			if (zip.size() == 0) {
+				message = messageSourceService.getMessage("owa.blank_zip");
+				log.warn("Zip file is empty");
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+				response.sendError(400, message);
+			} else {
+				ZipEntry entry = zip.getEntry("manifest.webapp");
+				if (entry == null) {
+					message = messageSourceService.getMessage("owa.manifest_not_found");
+					log.warn("Manifest file could not be found in app");
+					session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+					response.sendError(400, message);
+				} else {
+					String contextPath = request.getScheme() + "://" + request.getServerName() + ":"
+							+ request.getServerPort() + request.getContextPath();
+					appManager.installApp(file, fileName, contextPath);
+					message = messageSourceService.getMessage("owa.app_installed");
+					response.setStatus(200);
+					file.delete();
+					session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, message);
+					return Boolean.TRUE;
+				}
+			}
+			file.delete();
+			return Boolean.FALSE;
+		}
+		catch (Exception e) {
+			message = messageSourceService.getMessage("owa.not_a_zip");
+			log.warn("App is not a zip archive");
+			file.delete();
+			session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, message);
+			response.sendError(400, message);
+			return false;
+		}
+	}
+	
+	private String getPassedFileName(String installUrl) {
+		String passedFileName = null;
+		if (installUrl.contains("file_path=")) {
+			passedFileName = StringUtils.substringBetween(installUrl, "file_path=", ".zip");
+		} else {
+			passedFileName = FilenameUtils.getName(installUrl);
+		}
+		return getFileName(passedFileName);
+	}
+	
+	private String getFileName(String passedFileName) {
+		String[] tokens = passedFileName.split("((-|[_])+[0-9])|[\\s]");
+		String fileName = tokens[0];
+		if (fileName != null && !fileName.contains(".zip")) {
+			fileName += ".zip";
+		}
+		return fileName;
 	}
 }


### PR DESCRIPTION
## JIRA TICKET NAME:
[OWA-70: Fix generated owa url after installation of OWA](https://issues.openmrs.org/browse/OWA-70)

## SUMMARY:
Make the url that is generated after the installation of the owa uniform. As of now, it takes on either the name of the OWA which can have spaces in it, or the name of the bundled file that is meant to have version numbers that change as newer versions come in.