### PR TITLE
OWA-71: Changing login redirect from legacy-ui login to add-on manager login

### DIFF
--- a/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
+++ b/omod/src/main/java/org/openmrs/module/owa/filter/OwaFilter.java
@@ -8,6 +8,7 @@ package org.openmrs.module.owa.filter;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.owa.AppManager;
+import org.openmrs.module.owa.utils.OwaUtils;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -49,7 +50,7 @@ public class OwaFilter implements Filter {
 			requestURL = request.getServletPath();
 		}
 		
-		if (Context.isAuthenticated()) {
+		if (OwaUtils.checkIfAddonManager(requestURL) || Context.isAuthenticated()) {
 			if (requestURL.startsWith(owaBasePath)) {
 				String newURL = requestURL.replace(owaBasePath, "/ms/owa/fileServlet");
 				req.getRequestDispatcher(newURL).forward(req, res);
@@ -65,7 +66,7 @@ public class OwaFilter implements Filter {
 			}
 		}
 	}
-	
+
 	//owaBasePath can be either full path (must contain protocol) or relative servlet path
 	public static boolean isFullBasePath(String owaBasePath) {
 		return owaBasePath.contains("://");

--- a/omod/src/main/java/org/openmrs/module/owa/servlet/RedirectServlet.java
+++ b/omod/src/main/java/org/openmrs/module/owa/servlet/RedirectServlet.java
@@ -51,6 +51,6 @@ public class RedirectServlet extends HttpServlet {
 	        throws IOException {
 		String url = request.getRequestURL().toString().replace("/ms/owa/redirectServlet", "/owa");
 		//@TODO redirecting to original url after login in openmrs.
-		response.sendRedirect(request.getContextPath() + "/login.htm?redirect=" + url);
+		response.sendRedirect(request.getContextPath() + "/owa/addonmanager/index.html#/login?redirect=" + url);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/owa/utils/OwaUtils.java
+++ b/omod/src/main/java/org/openmrs/module/owa/utils/OwaUtils.java
@@ -44,4 +44,12 @@ public class OwaUtils {
 		}
 		return fileName;
 	}
+	
+	/**
+	 * @param requestURL URL to be checked
+	 * @return Boolean object to confirm whether URL contains "addonmanager"
+	 */
+	public static Boolean checkIfAddonManager(String requestURL) {
+		return requestURL.contains("/owa/addonmanager/index.html") ? true : false;
+	}
 }

--- a/omod/src/test/java/org/openmrs/module/owa/utils/OwaUtilsTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/utils/OwaUtilsTest.java
@@ -4,6 +4,28 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class OwaUtilsTest {
+
+	private static String DEFAULT_APP_BASE_URL = "http://localhost:80/openmrs/owa";
+	
+	private static String ADDONMANGER_URL = "/addonmanager/index.html";
+	
+	private static String SOME_PATH_IN_APP = "/anything/index.html";
+	
+	/**
+	 * Test that checkIfAddOnManager() returns true if the request URL contains "addonmanager"
+	 */
+	@Test
+	public void testCheckIfAddOnManagerReturnsTrueIfAddonmanagerExists() throws Exception {
+		Assert.assertEquals(new Boolean(true), OwaUtils.checkIfAddonManager(DEFAULT_APP_BASE_URL + ADDONMANGER_URL));
+	}
+	
+	/**
+	 * Test that checkIfAddOnManager() returns false if the request URL does not contain "addonmanager"
+	 */
+	@Test
+	public void testCheckIfAddOnManagerReturnsFalseIfAddonmanagerDoesNotExist() throws Exception {
+		Assert.assertEquals(new Boolean(false), OwaUtils.checkIfAddonManager(DEFAULT_APP_BASE_URL + SOME_PATH_IN_APP));
+	}
 	
 	@Test
 	public void testgetFileNameWithNoQueryString() {
@@ -25,5 +47,5 @@ public class OwaUtilsTest {
 		String fileName = OwaUtils.removeVersionNumber(testString);
 		Assert.assertEquals(fileName, "cohortbuilder.zip");
 	}
-	
+
 }


### PR DESCRIPTION
### JIRA Ticket
[[OWA-71] Changing login redirect from legacy-ui login to add-on manager login](https://issues.openmrs.org/browse/OWA-71)

### Description
When accessing the add-on manager when one is not authenticated would result to being redirected to the login page of the legacyUI. This should be altered such that it redirects to the login page that has been added to the add-on manager

Changes similar to [PR-64](https://github.com/openmrs/openmrs-module-owa/pull/64)