### PR TITLE
Updating to Platform 1.11.0

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -77,6 +77,12 @@
             <scope>test</scope>
         </dependency>
         <!-- End OpenMRS core -->
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-jasper</artifactId>
+            <scope>provided</scope>
+        </dependency>
         
     </dependencies>
 

--- a/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/filter/OwaFilterTest.java
@@ -106,7 +106,7 @@ public class OwaFilterTest extends BaseModuleWebContextSensitiveTest {
 		req = new MockHttpServletRequest("GET", "openmrs/index.htm");
 		req.setServletPath("/index.htm");
 		owaFilter.doFilter(req, rsp, mockFilterChain);
-		Assert.assertEquals(rsp.getStatus(), 200);
+		Assert.assertEquals(rsp.getStatus(), 302);
 		Assert.assertEquals("/" + ADD_ON_MANAGER_REDIRECT_URL, rsp.getRedirectedUrl());
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/owa/impl/DefaultAppManagerTest.java
+++ b/omod/src/test/java/org/openmrs/module/owa/impl/DefaultAppManagerTest.java
@@ -60,7 +60,7 @@ public class DefaultAppManagerTest extends BaseModuleWebContextSensitiveTest {
 	
 	@Before
 	public void setUp() throws Exception {
-		initMocks(this);
+		initMocks();
 		appManager = new DefaultAppManager();
 		appManager.setOwaListeners(Arrays.asList(listener));
 		owaDir = Files.createTempDirectory("owa").toFile();

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </modules>
 	
     <properties>
-        <openMRSVersion>1.9.7</openMRSVersion>
+        <openMRSVersion>1.11.0</openMRSVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -106,6 +106,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.21</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-jasper</artifactId>
+                <version>8.5.100</version>
+                <scope>provided</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
This updates the OpenMRS platform version to 1.11.0. I added the apache-jasper dependency to fix the following error.

`
java.io.FileNotFoundException: class path resource [org/apache/jasper/servlet/JspServlet.class] cannot be opened because it does not exist
`